### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Toast Framework
-The Toast framework is a grid. That's it. Soon, it might have type styles and whatnot, but it's power is in its highly customisable design.
+The Toast framework is a grid. That's it. Soon, it might have type styles and whatnot, but its power is in its highly customisable design.
 
 Set any number of columns, any gutter size you want, and whatever classes you need. Just edit the `_grid.scss` file’s variables to your needs.
 


### PR DESCRIPTION
Assuming you meant to use the possessive “its” as opposed to the contracted version “it’s” when referring to Toast’s power.
