### PR TITLE
Remove http: from fonts.google.com

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,7 +9,7 @@
 
   <script type="text/javascript" src="//use.typekit.net/fcy7mfm.js"></script>
   <script type="text/javascript">try{Typekit.load();}catch(e){}</script>
-  <link href='http://fonts.googleapis.com/css?family=Source+Code+Pro:400,600' rel='stylesheet' type='text/css' />
+  <link href='//fonts.googleapis.com/css?family=Source+Code+Pro:400,600' rel='stylesheet' type='text/css' />
 </head>
 <body>
   <div class="wrap">


### PR DESCRIPTION
So your page doesn't load insecure content over https.
